### PR TITLE
udev: import filesystem metadata for fioX

### DIFF
--- a/tools/udev/rules.d/60-persistent-fio.rules
+++ b/tools/udev/rules.d/60-persistent-fio.rules
@@ -17,6 +17,9 @@ ENV{DEVTYPE}=="partition", \
   IMPORT{parent}="ID_F[!S]*", IMPORT{parent}="ID_F", \
   IMPORT{parent}="ID_FS[!_]*", IMPORT{parent}="ID_FS"
 
+# probe filesystem metadata of disks
+IMPORT{builtin}="blkid"
+
 # by-id
 KERNEL=="fio[a-z]", PROGRAM="/usr/bin/fio-status --field iom.format_uuid /dev/%k", SYMLINK+="disk/by-id/fio-%c"
 KERNEL=="fio[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/usr/bin/fio-status --field iom.format_uuid /dev/%P", SYMLINK+="disk/by-id/fio-%c-part%n"


### PR DESCRIPTION
LVM auto activation is triggered by udev discovering the LVM PVs and populating ID_FS_TYPE.  60-persistent-fio.rules already runs blkid on partitions on the fioX device to create /dev/disk/by-uuid symlinks. Add an import of filesystem metadata on the fioX device using udev's blkid builtin.

Fixes https://github.com/RemixVSL/iomemory-vsl/issues/55