### PR TITLE
6.1.1 support

### DIFF
--- a/root/usr/src/iomemory-vsl-3.2.16/Makefile
+++ b/root/usr/src/iomemory-vsl-3.2.16/Makefile
@@ -64,9 +64,9 @@ KFIO_LIB_CMD ?= kfio/.$(TARGET)_libkfio.o.cmd
 
 NCPUS:=$(shell grep -c ^processor /proc/cpuinfo)
 
-all: fake_license check_n_fix_kfio_ccver modules patch_module_version
+all: fake_license modules patch_module_version
 
-gpl: fake_license check_n_fix_kfio_ccver modules patch_module_version
+gpl: fake_license modules patch_module_version
 
 .PHONY: fake_license
 fake_license:

--- a/root/usr/src/iomemory-vsl-3.2.16/Makefile
+++ b/root/usr/src/iomemory-vsl-3.2.16/Makefile
@@ -64,9 +64,9 @@ KFIO_LIB_CMD ?= kfio/.$(TARGET)_libkfio.o.cmd
 
 NCPUS:=$(shell grep -c ^processor /proc/cpuinfo)
 
-all: fake_license modules patch_module_version
+all: fake_license check_n_fix_kfio_ccver modules patch_module_version
 
-gpl: fake_license modules patch_module_version
+gpl: fake_license check_n_fix_kfio_ccver modules patch_module_version
 
 .PHONY: fake_license
 fake_license:

--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.16.14"
-PREV_KERNEL_SRC="/lib/modules/5.16.14/build"
+PREV_KERNELVER="5.19.0-26-generic"
+PREV_KERNEL_SRC="/lib/modules/5.19.0-26-generic/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.19.0-24-generic"
-PREV_KERNEL_SRC="/lib/modules/5.19.0-24-generic/build"
+PREV_KERNELVER="5.19.0-26-generic"
+PREV_KERNEL_SRC="/lib/modules/5.19.0-26-generic/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.19.0-26-generic"
-PREV_KERNEL_SRC="/lib/modules/5.19.0-26-generic/build"
+PREV_KERNELVER="5.19.0-24-generic"
+PREV_KERNEL_SRC="/lib/modules/5.19.0-24-generic/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/kblock_meta.h
@@ -7,9 +7,12 @@
 #ifndef __FIO_KBLOCK_META_H__
 #define __FIO_KBLOCK_META_H__
 
+#include <linux/version.h>
+
 #if KFIOC_X_LINUX_HAS_PART_STAT_H
 #include <linux/part_stat.h>
 #endif /* KFIOC_X_LINUX_HAS_PART_STAT_H */
+
 
 #if KFIOC_X_BLK_ALLOC_DISK_EXISTS
   #define BLK_ALLOC_QUEUE dp->gd->queue;
@@ -21,22 +24,24 @@
   #define BLK_ALLOC_DISK alloc_disk
 #endif
 
+
 #if KFIOC_X_BIO_HAS_BI_BDEV
   #define BIO_DISK bi_bdev->bd_disk
 #else /* KFIOC_X_BIO_HAS_BI_BDEV */
   #define BIO_DISK bi_disk
 #endif /* KFIOC_X_BIO_HAS_BI_BDEV */
 
+
 #if KFIOC_X_HAS_MAKE_REQUEST_FN
   static unsigned int kfio_make_request(struct request_queue *queue, struct bio *bio);
   #define KFIO_SUBMIT_BIO_RC return FIO_MFN_RET;
-
   #define BLK_QUEUE_SPLIT blk_queue_split(queue, &bio);
+
   #if KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS
     #define BLK_ALLOC_QUEUE blk_alloc_queue_node(GFP_NOIO, node);
   #elif KFIOC_X_BLK_ALLOC_QUEUE_EXISTS
     #define BLK_ALLOC_QUEUE blk_alloc_queue(GFP_NOIO);
-  #else /* KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS */
+  #else
     #define BLK_ALLOC_QUEUE blk_alloc_queue(kfio_make_request, node);
   #endif /* KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS */
 
@@ -49,27 +54,45 @@
     #define KFIO_SUBMIT_BIO_RC
   #endif
   KFIO_SUBMIT_BIO;
-
   #define BLK_QUEUE_SPLIT blk_queue_split(&bio);
 #endif /* KFIOC_X_HAS_MAKE_REQUEST_FN */
+
+// should check for hd_struct vs gendisk
 #if KFIOC_X_GENHD_PART0_IS_A_POINTER
-  #define GD_PART0 gd->part0
+  #define GD_PART0 disk->gd->part0
   #define GET_BDEV disk->gd->part0
 #else /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
-  #define GD_PART0 &gd->part0
-  #define GET_BDEV bdgrab(disk->gd->part0);
+  #define GD_PART0 &disk->gd->part0
+  #define GET_BDEV bdget_disk(disk->gd, 0);
 #endif /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
+
 
 #if KFIOC_X_VOID_ADD_DISK
 #define ADD_DISK add_disk(disk->gd);
 #else
 #define ADD_DISK if (add_disk(disk->gd)) { infprint("Error while adding disk!"); }
-#endif
+#endif /* KFIOC_X_VOID_ADD_DISK */
 
 #if KFIOC_X_DISK_HAS_OPEN_MUTEX
 #define SHUTDOWN_MUTEX &disk->gd->open_mutex
 #else
 #define SHUTDOWN_MUTEX &linux_bdev->bd_mutex
+#endif /* KFIOC_X_DISK_HAS_OPEN_MUTEX */
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
+// 5.17 moved GD to explicitly do this by default
+#define KFIO_DISABLE_GENHD_FL_EXT_DEVT 1
+#endif
+
+// while (atomic_read(&linux_bdev->bd_openers) > 0 && linux_bdev->bd_disk == disk->gd)
+// 5.19 changed bd_openers from int to atomic_t in kblock.c
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0)
+#define BD_OPENERS atomic_read(&linux_bdev->bd_openers)
+#define SET_QUEUE_FLAG_DISCARD
+#else
+#define BD_OPENERS linux_bdev->bd_openers
+// https://lore.kernel.org/linux-btrfs/20220409045043.23593-25-hch@lst.de/
+#define SET_QUEUE_FLAG_DISCARD blk_queue_flag_set(QUEUE_FLAG_DISCARD, rq);
 #endif
 
 #endif /* __FIO_KBLOCK_META_H__ */

--- a/root/usr/src/iomemory-vsl-3.2.16/include/kfile_meta.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/kfile_meta.h
@@ -9,11 +9,11 @@
 
 #include <linux/version.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
-#define KFIO_PDE_DATA pde_data(ip)
-#else
+#if defined(PDE_DATA)
 #define KFIO_PDE_DATA PDE_DATA(ip)
-#endif
+#else
+#define KFIO_PDE_DATA pde_data(ip)
+#endif /* PDE_DATA */
 
 #endif /* __FIO_FILE_META_H__ */
 

--- a/root/usr/src/iomemory-vsl-3.2.16/include/kfile_meta.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/kfile_meta.h
@@ -1,0 +1,19 @@
+/*
+  This "meta" file is supposed to abstract things that change in kfile.c
+  and should provide simplified defines that are named after their function.
+  Both aimed at making the code cleaner, more readable and perhaps more
+  maintainable. Blocks should be isolated and only cover one item.
+ */
+#ifndef __FIO_KFILE_META_H__
+#define __FIO_KFILE_META_H__
+
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
+#define KFIO_PDE_DATA pde_data(ip)
+#else
+#define KFIO_PDE_DATA PDE_DATA(ip)
+#endif
+
+#endif /* __FIO_FILE_META_H__ */
+

--- a/root/usr/src/iomemory-vsl-3.2.16/kblock.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kblock.c
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+
 // Copyright (c) 2006-2014, Fusion-io, Inc.(acquired by SanDisk Corp. 2014)
 // Copyright (c) 2014-2015 SanDisk Corp. and/or all its affiliates. All rights reserved.
 //
@@ -429,7 +429,7 @@ void kfio_destroy_disk(kfio_disk_t *disk, destroy_type_t dt)
         }
 
         /* Stop delivery of new io from user. */
-        set_bit(QUEUE_FLAG_DEAD, &disk->rq->queue_flags);
+        set_bit(QUEUE_FLAG_DYING, &disk->rq->queue_flags);
 
         /*
          * Prevent request_fn callback from interfering with
@@ -470,7 +470,7 @@ void kfio_destroy_disk(kfio_disk_t *disk, destroy_type_t dt)
 
     if (disk->rq != NULL)
     {
-        blk_cleanup_queue(disk->rq);
+        // blk_cleanup_queue(disk->rq);
         disk->rq = NULL;
     }
 

--- a/root/usr/src/iomemory-vsl-3.2.16/kblock.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kblock.c
@@ -942,7 +942,7 @@ static struct request_queue *kfio_alloc_queue(struct kfio_disk *dp,
     if (rq != NULL)
     {
         rq->queuedata = dp;
-#if (KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS) && KFIOC_X_HAS_MAKE_REQUEST_FN
+#if KFIOC_X_HAS_MAKE_REQUEST_FN
         blk_queue_make_request(rq, kfio_make_request);
 #endif
         // TODO:

--- a/root/usr/src/iomemory-vsl-3.2.16/kfile.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kfile.c
@@ -41,6 +41,7 @@
 #include <linux/proc_fs.h>
 #endif /* KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS */
 #include <fio/port/common-linux/kfile.h>
+#include <kfile_meta.h>
 
 /**
  * @ingroup PORT_COMMON_LINUX
@@ -144,7 +145,7 @@ void noinline kfio_seq_commit(fusion_seq_file *sp, int num)
 */
 void *noinline kfio_inode_data(fusion_inode *ip)
 {
-    return PDE_DATA(ip);
+    return KFIO_PDE_DATA;
 }
 
 /**

--- a/root/usr/src/iomemory-vsl-3.2.16/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl-3.2.16/kfio_config.sh
@@ -76,6 +76,7 @@ KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS
 KFIOC_X_TASK_HAS_CPUS_MASK
 KFIOC_X_LINUX_HAS_PART_STAT_H
 KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS
+KFIOC_X_BLK_ALLOC_QUEUE_EXISTS
 KFIOC_X_BLK_ALLOC_DISK_EXISTS
 KFIOC_X_HAS_MAKE_REQUEST_FN
 KFIOC_X_GENHD_PART0_IS_A_POINTER
@@ -257,7 +258,7 @@ void kfioc_has_make_request_fn(void)
 # usage:           1   Kernels that do have blk_alloc_queue_node
 #                  0   Kernels that don't have blk_alloc_queue_node
 # kernel_version:  In 5.7 blk_alloc_queue_node got removed and introduced block_alloc_queue,
- #                  which simplifies things
+ #                 which simplifies things
 KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS()
 {
     local test_flag="$1"
@@ -274,6 +275,25 @@ void kfioc_check_blk_alloc_queue_node(void)
     kfioc_test "$test_code" "$test_flag" 1 -Werror
 }
 
+# flag:            KFIOC_X_BLK_ALLOC_QUEUE_EXISTS
+# usage:           1   Kernels that do have blk_alloc_queue
+#                  0   Kernels that don't have blk_alloc_queue
+# kernel_version:  In 5.7 blk_alloc_queue node got removed and introduced block_alloc_queue,
+#                  which simplifies things
+KFIOC_X_BLK_ALLOC_QUEUE_EXISTS()
+{
+    local test_flag="$1"
+    local test_code='
+#include <linux/blkdev.h>
+void kfioc_check_blk_alloc_queue(void)
+{
+  struct request_queue *rq;
+  int node = 1;
+  rq = blk_alloc_queue(node);
+}
+'
+    kfioc_test "$test_code" "$test_flag" 1 -Werror
+}
 
 # flag:            KFIOC_X_LINUX_HAS_PART_STAT_H
 # usage:           1   Kernels that have linux/part_stats.h
@@ -329,11 +349,11 @@ KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS()
 
 void *kfioc_has_proc_create_data(struct inode *inode)
 {
-    const struct proc_ops *pops;
+    const struct proc_ops *pops = NULL;
     return proc_create_data(NULL, 0, NULL, pops, NULL);
 }
 '
-    kfioc_test "$test_code" "$test_flag" 1 -Werror-implicit-function-declaration
+    kfioc_test "$test_code" "$test_flag" 1 "-Werror-implicit-function-declaration -Werror"
 }
 
 #

--- a/root/usr/src/iomemory-vsl-3.2.16/kscatter.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kscatter.c
@@ -338,8 +338,9 @@ int kfio_sgl_dma_map(kfio_sg_list_t *sgl, kfio_dma_map_t *dmap, int dir)
         sl = &lsg->sl[i];
     }
 
-    i = pci_map_sg(lsg->pci_dev, lsg->sl, lsg->num_entries,
-                    dir == IODRIVE_DMA_DIR_READ ? PCI_DMA_FROMDEVICE : PCI_DMA_TODEVICE);
+    // TODO: Pull to cookie like vsl4?
+    i = dma_map_sg(&lsg->pci_dev->dev, lsg->sl, lsg->num_entries,
+                    dir == IODRIVE_DMA_DIR_READ ? DMA_FROM_DEVICE : DMA_TO_DEVICE);
     lsg->num_mapped = i;
     if (i < lsg->num_entries)
     {
@@ -370,6 +371,7 @@ bail:
 }
 KFIO_EXPORT_SYMBOL(kfio_sgl_dma_map);
 
+/* TODO: This could become the same as vsl4 if we have a cookie... */
 int kfio_sgl_dma_unmap(kfio_sg_list_t *sgl)
 {
     struct linux_sgl *lsg = sgl;
@@ -385,8 +387,8 @@ int kfio_sgl_dma_unmap(kfio_sg_list_t *sgl)
     }
     if (lsg->num_mapped)
     {
-        pci_unmap_sg(lsg->pci_dev, lsg->sl, lsg->num_entries,
-                 lsg->pci_dir == IODRIVE_DMA_DIR_READ ? PCI_DMA_FROMDEVICE : PCI_DMA_TODEVICE);
+        dma_unmap_sg(&lsg->pci_dev->dev, lsg->sl, lsg->num_entries,
+                 lsg->pci_dir == IODRIVE_DMA_DIR_READ ? DMA_FROM_DEVICE : DMA_TO_DEVICE);
     }
     lsg->num_mapped = 0;
     lsg->pci_dir = 0;

--- a/root/usr/src/iomemory-vsl-3.2.16/pci.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/pci.c
@@ -525,7 +525,7 @@ int kfio_pci_request_regions(kfio_pci_dev_t *pdev, const char *res_name)
 
 int kfio_pci_set_dma_mask(kfio_pci_dev_t *pdev, uint64_t mask)
 {
-    return pci_set_dma_mask((struct pci_dev *)pdev, mask);
+    return dma_set_mask(&((struct pci_dev *)pdev)->dev, mask);
 }
 
 void kfio_pci_set_master(kfio_pci_dev_t *pdev)


### PR DESCRIPTION
Move forward to Kernel 6.1.1 (tested on Arch). Fixes for CentOS 8 and CentOS 9 also.