### PR TITLE
Fix missing prototypes

### DIFF
--- a/root/usr/src/iomemory-vsl-3.2.16/Makefile
+++ b/root/usr/src/iomemory-vsl-3.2.16/Makefile
@@ -35,9 +35,7 @@ KERNEL_SRC = /lib/modules/$(KERNELVER)/source
 
 # Set PORT_NO_WERROR=0 to compile without -Werror compilation flag
 ifneq ($(PORT_NO_WERROR),1)
-    ifeq ($(FIO_DRIVER_NAME), iomemory-vsl)
-        CFLAGS += -Werror
-    endif
+    CFLAGS += -Werror
 endif
 
 # Set FUSION_DEBUG=0 to compile without debugging symbols
@@ -91,7 +89,7 @@ clean modules_clean:
 		EXTRA_CFLAGS+="$(CFLAGS)" \
 		KFIO_LIB=$(KFIO_LIB) \
 		clean
-	rm -rf include/fio/port/linux/kfio_config.h kfio_config license.c
+	rm -rf include/fio/port/linux/kfio_config.h kfio_config
 
 include/fio/port/linux/kfio_config.h: kfio_config.sh
 	./$< -a $(FIOARCH) -o $@ -k $(KERNEL_BUILD) -p -d $(CURDIR)/kfio_config -l $(FUSION_DEBUG) -s $(KERNEL_SRC)

--- a/root/usr/src/iomemory-vsl-3.2.16/cdev.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/cdev.c
@@ -38,6 +38,9 @@
 #include <linux/miscdevice.h>
 #include <linux/poll.h>
 
+int fusion_create_control_device(struct fusion_nand_device *nand_dev);
+int fusion_destroy_control_device(struct fusion_nand_device *nand_dev);
+
 /**
  * @ingroup PORT_COMMON_LINUX
  * @{

--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="6.2.0-37-generic"
-PREV_KERNEL_SRC="/lib/modules/6.2.0-37-generic/build"
+PREV_KERNELVER="6.5.0-26-generic"
+PREV_KERNEL_SRC="/lib/modules/6.5.0-26-generic/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/include/fio/port/state.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/fio/port/state.h
@@ -50,6 +50,9 @@ typedef struct
 #endif
 } fio_state_t;
 
+void fio_state_up(fio_state_t *s);
+void fio_state_down(fio_state_t *s);
+
 #define FIO_STATE_INVALID           0
 
 #ifndef FIO_DEFINE_STATE_NAMES

--- a/root/usr/src/iomemory-vsl-3.2.16/kblock.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kblock.c
@@ -48,6 +48,15 @@
 #include <linux/buffer_head.h>
 #include <kblock_meta.h>
 
+kfio_bio_t *kfio_fetch_next_bio(struct kfio_disk *disk);
+int kfio_vectored_atomic(struct block_device *bdev,
+                         const struct kfio_iovec *iov,
+                         uint32_t iovcnt,
+                         bool user_pages);
+int kfio_count_sectors_inuse(struct block_device *bdev,
+                             uint64_t base,
+                             uint64_t length,
+                             uint64_t *count);
 extern int use_workqueue;
 static int fio_major;
 

--- a/root/usr/src/iomemory-vsl-3.2.16/kcondvar.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kcondvar.c
@@ -39,6 +39,11 @@
 #include <linux/sched.h>    // for struct task_struct used in kassert
 #endif
 
+int noinline __fusion_condvar_timedwait(fusion_condvar_t *cv,
+                                      fusion_cv_lock_t *lock,
+                                      int64_t timeout_us,
+                                      int interruptible);
+
 /**
  * @ingroup PORT_COMMON_LINUX
  * @{

--- a/root/usr/src/iomemory-vsl-3.2.16/kcsr.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kcsr.c
@@ -28,7 +28,14 @@
 #if defined(__KERNEL__)
 #include "port-internal.h"
 #include <asm/io.h>
-#else
+
+uint32_t kfio_csr_read_direct(volatile void *addr, void *hdl);   
+uint64_t kfio_csr_read_direct_64(volatile void *addr, void *hdl);
+void kfio_csr_write_nobarrier(uint32_t val, volatile void *addr, void *hdl);
+void kfio_csr_write(uint32_t val, volatile void *addr, void *hdl);
+void kfio_csr_write_64(uint64_t val, volatile void *addr, void *hdl);
+
+#else /* not defined __KERNEL */
 #include <fio/port/utypes.h>
 #include <fio/port/ufio.h>
 

--- a/root/usr/src/iomemory-vsl-3.2.16/kfio.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kfio.c
@@ -55,6 +55,9 @@
 #include <fio/port/sched.h>
 #include <fio/port/kfio_config.h>
 
+void noinline fusion_spin_lock_irq(fusion_spinlock_t *s);
+void noinline fusion_spin_unlock_irq(fusion_spinlock_t *s);
+
 /**
  * @ingroup PORT_LINUX
  * @{

--- a/root/usr/src/iomemory-vsl-3.2.16/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl-3.2.16/kfio_config.sh
@@ -123,6 +123,7 @@ KFIOC_X_HANDLE_SYSRQ_IS_U8()
     local test_code='
 #include <linux/sysrq.h>
 
+void kfioc_check_handle_sysrq_is_u8(void);
 void kfioc_check_handle_sysrq_is_u8(void)
 {
     void t_handle_sysreq(u8 key) {};
@@ -149,6 +150,7 @@ KFIOC_X_BDOPS_OPEN_GENDISK_AND_BLK_MODE_T()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_bdops_open_is_disk(void);
 void kfioc_check_bdops_open_is_disk(void)
 {
   struct block_device_operations *bops = NULL;
@@ -173,6 +175,7 @@ KFIOC_X_BDOPS_RELEASE_1_ARG()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_bdops(void);
 void kfioc_check_bdops(void)
 {
   struct block_device_operations *bops = NULL;
@@ -194,6 +197,7 @@ KFIOC_X_CAPS_PDE_DATA()
     local test_flag="$1"
     local test_code='
 #include <linux/proc_fs.h>
+void kfioc_check_caps_pde_data(void);
 void kfioc_check_caps_pde_data(void)
 {
   struct inode *i = NULL;
@@ -214,6 +218,7 @@ KFIOC_X_BIO_SPLIT_TO_LIMITS()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_bio_split_to_limits(void);
 void kfioc_check_bio_split_to_limits(void)
 {
   struct bio *bio = NULL;
@@ -233,6 +238,7 @@ KFIOC_X_SUBMIT_BIO_RETURNS_BLK_QC_T()
     local test_flag="$1"
     local test_code='
 #include <linux/bio.h>
+void kfioc_check_submit_bio_returns_blk_qc_t(void);
 void kfioc_check_submit_bio_returns_blk_qc_t(void)
 {
   struct bio *bio = NULL;
@@ -253,6 +259,7 @@ KFIOC_X_VOID_ADD_DISK()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_void_add_disk(void);
 void kfioc_check_void_add_disk(void)
 {
   struct gendisk *gd = NULL;
@@ -274,6 +281,7 @@ KFIOC_X_DISK_HAS_OPEN_MUTEX()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_disk_open_mutex(void);
 void kfioc_check_disk_open_mutex(void)
 {
   struct gendisk *gd = NULL;
@@ -295,6 +303,7 @@ KFIOC_X_BLK_ALLOC_DISK_EXISTS()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_blk_alloc_disk(void);
 void kfioc_check_blk_alloc_disk(void)
 {
   struct gendisk *gd;
@@ -317,6 +326,7 @@ KFIOC_X_BIO_HAS_BI_BDEV()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_bio_has_bi_bdev(void);
 void kfioc_bio_has_bi_bdev(void)
  {
   struct bio *bio = NULL;
@@ -339,6 +349,7 @@ KFIOC_X_GENHD_PART0_IS_A_POINTER()
     local test_code='
 #include <linux/blkdev.h>
 #include <linux/part_stat.h>
+void kfioc_genhd_part0_is_a_pointer(void);
 void kfioc_genhd_part0_is_a_pointer(void)
 {
   struct gendisk *gd = NULL;
@@ -357,6 +368,7 @@ KFIOC_X_HAS_MAKE_REQUEST_FN()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_has_make_request_fn(void);
 void kfioc_has_make_request_fn(void)
 {
   struct kfio_disk
@@ -378,6 +390,7 @@ KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_blk_alloc_queue_node(void);
 void kfioc_check_blk_alloc_queue_node(void)
 {
   struct request_queue *rq;
@@ -399,6 +412,7 @@ KFIOC_X_BLK_ALLOC_QUEUE_EXISTS()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_blk_alloc_queue(void);
 void kfioc_check_blk_alloc_queue(void)
 {
   struct request_queue *rq;
@@ -418,6 +432,7 @@ KFIOC_X_TASK_HAS_CPUS_MASK()
     local test_flag="$1"
     local test_code='
 #include <linux/sched.h>
+void kfioc_check_task_has_cpus_mask(void);
 void kfioc_check_task_has_cpus_mask(void)
 {
     cpumask_t *cpu_mask = NULL;
@@ -443,6 +458,7 @@ KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS()
     local test_code='
 #include <linux/proc_fs.h>
 
+void *kfioc_has_proc_create_data(struct inode *inode);
 void *kfioc_has_proc_create_data(struct inode *inode)
 {
     const struct proc_ops *pops = NULL;

--- a/root/usr/src/iomemory-vsl-3.2.16/kscatter.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kscatter.c
@@ -33,6 +33,9 @@
 #include <fio/port/ktime.h>
 #include <linux/version.h>
 
+int kfio_sgl_map_bio(kfio_sg_list_t *sgl, struct bio *pbio);
+void *kfio_sgl_get_byte_pointer(kfio_sg_list_t *sgl, uint32_t offset);
+
 #ifndef MIN
 #define MIN(a, b)   (((a) < (b)) ? (a) : (b))
 #endif

--- a/root/usr/src/iomemory-vsl-3.2.16/main.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/main.c
@@ -64,6 +64,8 @@
 #define FIO_CONFIG_MACRO(dbgf) [_DF_ ## dbgf] = { .name = #dbgf, .mode = S_IRUGO | S_IWUSR, .value = dbgf },
 #endif
 
+void __exit exit_fio_driver(void);
+
 /**
  * @ingroup PORT_COMMON_LINUX
  * @{

--- a/root/usr/src/iomemory-vsl-3.2.16/pci.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/pci.c
@@ -41,6 +41,17 @@
 #include <fio/port/kfio.h>
 #include <fio/port/kpci.h>
 
+irqreturn_t kfio_handle_irq_wrapper(int irq, void *dev_id);
+irqreturn_t kfio_handle_irqx_wrapper(int irq, void *dev_id);
+void kfio_pci_disable_device(kfio_pci_dev_t *pdev);
+int kfio_pci_enable_device(kfio_pci_dev_t *pdev);
+void kfio_pci_release_regions(kfio_pci_dev_t *pdev);
+int kfio_pci_request_regions(kfio_pci_dev_t *pdev, const char *res_name);
+int kfio_pci_set_dma_mask(kfio_pci_dev_t *pdev, uint64_t mask);
+void kfio_pci_set_master(kfio_pci_dev_t *pdev);
+int kfio_pci_register_driver(void);
+void kfio_pci_unregister_driver(void);
+
 /*************************************************************************************/
 /*   Legacy and MSI interrupts.                                                      */
 /*************************************************************************************/

--- a/root/usr/src/iomemory-vsl-3.2.16/state.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/state.c
@@ -30,9 +30,6 @@
 #include <fio/port/state.h>
 #include <fio/port/dbgset.h>
 
-void fio_state_up(fio_state_t *s);
-void fio_state_down(fio_state_t *s);
-
 /**
  * @brief __fio_state_in_one_of_locked -  compare -- lock must be held by caller
  */

--- a/root/usr/src/iomemory-vsl-3.2.16/state.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/state.c
@@ -30,6 +30,9 @@
 #include <fio/port/state.h>
 #include <fio/port/dbgset.h>
 
+void fio_state_up(fio_state_t *s);
+void fio_state_down(fio_state_t *s);
+
 /**
  * @brief __fio_state_in_one_of_locked -  compare -- lock must be held by caller
  */

--- a/root/usr/src/iomemory-vsl-3.2.16/sysrq.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/sysrq.c
@@ -35,6 +35,10 @@
 #include <fio/port/dbgset.h>
 #include <sysrq_meta.h>
 
+void iodrive_handle_sysrq(HANDLE_SYSRQ_TYPE key);
+void kfio_iodrive_sysrq_keys(void);
+void kfio_iodrive_unreg_sysrq_keys(void);
+
 /**
  * @ingroup PORT_COMMON_LINUX
  * @{


### PR DESCRIPTION
There were some prototypes missing for the tests and the driver. This commit adds the prototypes and turns on -Werror again, as it should be on.