### PR TITLE
Fix thunk on 6.10 and above

### DIFF
--- a/root/usr/src/iomemory-vsl-3.2.16/Makefile
+++ b/root/usr/src/iomemory-vsl-3.2.16/Makefile
@@ -28,7 +28,14 @@ else
 KERNELVER ?= $(shell uname -r)
 endif
 KERNEL_BUILD = /lib/modules/$(KERNELVER)/build
-CFLAGS = -I$(shell pwd)/include -DBUILDING_MODULE -DLINUX_IO_SCHED -mfunction-return=keep -Wall
+CFLAGS = -I$(shell pwd)/include -DBUILDING_MODULE -DLINUX_IO_SCHED -Wall
+
+KMAJ ?= $(grep -m 1 VERSION ${KERNEL_MAKEFILE} | sed 's/^.*= //g')
+KMIN ?= $(grep -m 1 PATCHLEVEL ${KERNEL_MAKEFILE} | sed 's/^.*= //g')
+GE_6_10 := $(shell [ $(KMAJ) -ge 10 -a \( $(KMIN) -ge 6 \) ] && echo true)
+ifeq ($(GE_6_10),true)
+CFLAGS += -mfunction-return=keep
+endif
 
 # Older systems (Debian 6) have the kernel headers in a different directory than the kernel build directory.
 # Start in this source directory, and fix it up in the config shell script if it isn't right.

--- a/root/usr/src/iomemory-vsl-3.2.16/Makefile
+++ b/root/usr/src/iomemory-vsl-3.2.16/Makefile
@@ -30,16 +30,19 @@ endif
 KERNEL_BUILD = /lib/modules/$(KERNELVER)/build
 CFLAGS = -I$(shell pwd)/include -DBUILDING_MODULE -DLINUX_IO_SCHED -Wall
 
-KMAJ ?= $(grep -m 1 VERSION ${KERNEL_MAKEFILE} | sed 's/^.*= //g')
-KMIN ?= $(grep -m 1 PATCHLEVEL ${KERNEL_MAKEFILE} | sed 's/^.*= //g')
-GE_6_10 := $(shell [ $(KMAJ) -ge 10 -a \( $(KMIN) -ge 6 \) ] && echo true)
-ifeq ($(GE_6_10),true)
-CFLAGS += -mfunction-return=keep
-endif
-
-# Older systems (Debian 6) have the kernel headers in a different directory than the kernel build directory.
+# Older systems (Debian 6) have the kernel headers in a different direct`ory than the kernel build directory.
 # Start in this source directory, and fix it up in the config shell script if it isn't right.
 KERNEL_SRC = /lib/modules/$(KERNELVER)/source
+
+# Really have to come up with something else than this hackery
+KDIR = $(or $(and $(wildcard $(KERNEL_SRC)/Makefile),"source"), "build")
+KERNEL_MAKEFILE = /lib/modules/$(KERNELVER)/$(KDIR)/Makefile
+KMAJ ?= $(shell grep -m 1 VERSION ${KERNEL_MAKEFILE} | sed 's/^.*= //g')
+KMIN ?= $(shell grep -m 1 PATCHLEVEL ${KERNEL_MAKEFILE} | sed 's/^.*= //g')
+GE_6_10 := $(shell [ "${KMAJ}" -ge "6" -a "${KMIN}" -ge "10" ] && echo true)
+ifeq ($(GE_6_10),true)
+	CFLAGS += -mfunction-return=keep
+endif
 
 # Set PORT_NO_WERROR=0 to compile without -Werror compilation flag
 ifneq ($(PORT_NO_WERROR),1)


### PR DESCRIPTION
Fixes the one off `thunk` on module loading in kernels above `6.10` by adding `-mfunction-return=keep` conditionally.

Compiling between `5.14`-ish and `6.9.0` and using `-mfunction-return=keep` will result in `objtool` complaining about `naked RETHUNK on return`. On `6.8.0` it will even result in the module not compiling. Hence For kernels below `6.10` we omit the `-mfunction-return=keep`. For now we add the CFLAGS with a conditonal from the `Makefile`. Though ideally this needs to change at some point.
