### PR TITLE
Sure erase mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ Historically releases were tagged, and were be checked out by their tag. The rel
 ## Important Note for newer Linux Kernels
 Starting with Linux kernel 5.4.0, significant changes to the kernel were made that require additional boot time kernel flags for this driver to work. These affect AMD CPUs starting with 5.4.0, and Intel CPUs after about kernel 5.8.0. 
 
+### Sure Erase Mode
+Kernels that have `CONFIG_HARDENED_USERCOPY` enabled will cause `fio-sure-erase` to fail with a [[BUG] Kernel memory overwrite attempt detected to SLUB object 'fusion_user_ll_request'](https://github.com/RemixVSL/iomemory-vsl/issues/115). For this reason the kernel module parameter `sure_erase_mode` has been added, which defaults 0.
+
+Loading the module with `sure_erase_mode=1` enables `sure_erase_mode`, and disables auto attach for the drive(s). Enabling `sure_erase_mode` allows `fio-sure-erase` to function as it should. After having done a `fio-sure-erase` the module should be unloaded and loaded as normal.
+
+An example of loading the module is `sudo insmod ./iomemory-vsl.ko sure_erase_mode=1`, make sure to unload the module prior to loading it. When `sure_erase_mode` is enabled a log message will appear in dmesg that states `fioinf sure_erase_mode enabled, disabling auto_attach`. Besides this one off message a message will be generated for every time the criteria are met that break `fio-sure-erase`.
+
+Though only the control channel is impacted by this change it is advisable to not run the module in `fio_sure_erase` mode permanently, but only with the goal of running `fio-sure-erase`.
+
 ### Grub
 When using grub as your boot loader, add the following to your /etc/default/grub by looking for `GRUB_CMDLINE_LINUX_DEFAULT=""` and adding additional parameters inside the quotes.
 

--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="6.11.0-28-generic"
-PREV_KERNEL_SRC="/lib/modules/6.11.0-28-generic/build"
+PREV_KERNELVER="6.8.0-85-generic"
+PREV_KERNEL_SRC="/lib/modules/6.8.0-85-generic/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="6.8.0-85-generic"
-PREV_KERNEL_SRC="/lib/modules/6.8.0-85-generic/build"
+PREV_KERNELVER="6.14.0-28-generic"
+PREV_KERNEL_SRC="/lib/modules/6.14.0-28-generic/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/driver_init.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/driver_init.c
@@ -52,10 +52,9 @@ KFIO_MODULE_PARAM_ARRAY(numa_node_override, charp, &num_numa_node_override, S_IR
 
 int         sure_erase_mode = FIO_SURE_ERASE_MODE_DEFAULT;
 KFIO_MODULE_PARAM(sure_erase_mode, int, S_IRUGO | S_IWUSR);
-KFIO_MODULE_PARAM_DESC(sure_erase_mode, "Make the driver ignore calls that disturb fio-sure-erase with kernels that have protected user mode copy.");
+KFIO_MODULE_PARAM_DESC(sure_erase_mode, "Ignore calls that disturb fio-sure-erase with secure kernels, disables auto_attach.");
 
 int use_workqueue = USE_QUEUE_NONE;
-
 KFIO_MODULE_PARAM(use_workqueue, int, S_IRUGO | S_IWUSR);
 
 /**

--- a/root/usr/src/iomemory-vsl-3.2.16/driver_init.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/driver_init.c
@@ -32,6 +32,7 @@
 #include "fio/port/kfio.h"
 
 #define AUTO_ATTACH_DEFAULT 1
+#define FIO_SURE_ERASE_MODE_DEFAULT 0
 
 /**
  * @ingroup PORT_COMMON_LINUX
@@ -48,6 +49,10 @@ KFIO_MODULE_PARAM_DESC(numa_node_forced_local, "Only schedule fio-wq completion 
 
 KFIO_MODULE_PARAM_DESC(numa_node_override, "Override device to NUMA node binding");
 KFIO_MODULE_PARAM_ARRAY(numa_node_override, charp, &num_numa_node_override, S_IRUGO | S_IWUSR);
+
+int         sure_erase_mode = FIO_SURE_ERASE_MODE_DEFAULT;
+KFIO_MODULE_PARAM(sure_erase_mode, int, S_IRUGO | S_IWUSR);
+KFIO_MODULE_PARAM_DESC(sure_erase_mode, "Make the driver ignore calls that disturb fio-sure-erase with kernels that have protected user mode copy.");
 
 int use_workqueue = USE_QUEUE_NONE;
 

--- a/root/usr/src/iomemory-vsl-3.2.16/include/fio/port/port_config_vars_externs.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/fio/port/port_config_vars_externs.h
@@ -50,7 +50,6 @@ typedef struct _int_array_s_
 #endif // not defined INT_ARRAY_MAX_ELEMENTS  
 
 #if defined(__KERNEL__)
-
 extern int auto_attach ; //AUTO_ATTACH
 extern int compaction_timeout_ms ; //COMPACTION_TIMEOUT_MS
 extern int strict_sync ; //STRICT_SYNC

--- a/root/usr/src/iomemory-vsl-3.2.16/kfio_common.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kfio_common.c
@@ -41,6 +41,7 @@
  * @ingroup PORT_LINUX
  * @{
  */
+extern int sure_erase_mode;
 
 void
 __kassert_fail (const char *expr, const char *file, int line,
@@ -229,15 +230,63 @@ void fusion_create_kthread(fusion_kthread_func_t func, void *data, void *fusion_
  * XXX: all the kfio_[put\get]_user_*() routines are superfluous
  * and ought be replaced with kfio_copy_[to|from]_user()
  */
+/*
+ 8140 - 8170 is also valid.... if we deny the 8140 fio-sure-erase bombs on
+ not being able to backup the lebmap...
+ fusion_user_ll_request of size 3960 triggers this, which routes into fusion_pcie_get_dynamic_info
+ */
+#define MAX_USER_BUFFER_SIZE 9216
 int kfio_copy_from_user(void *to, const void *from, unsigned len)
 {
-    return copy_from_user(to, from, len);
+    if (sure_erase_mode == 0) {
+        return copy_from_user(to, from, len);
+    }
+    int result = -EINVAL;
+    infprint("sure_erase_mode: Copying %u bytes from user space to kernel space\n", len);
+    if (!from || !to) {
+        errprint("sure_erase_mode: NULL pointer passed to kfio_copy_from_user\n");
+        return result;
+    }
+    if (len > MAX_USER_BUFFER_SIZE) {
+        errprint("sure_erase_mode: Invalid user buffer size: %u\n", len);
+        return result;
+    }
+    if (len == 3960) {
+        infprint("sure_erase_mode: the copy that is triggered by fusion_pcie_get_dynamic_info: %p", from);
+        return result;
+    }
+    // kmem_cache_create_usercopy
+    result = copy_from_user(to, from, len);
+    if (result) {
+        errprint("sure_erase_mode: Failed to copy %u bytes from user space, %d bytes not copied\n", len, result);
+        return -EFAULT;
+    }
+    return result;
 }
 KFIO_EXPORT_SYMBOL(kfio_copy_from_user);
 
 int kfio_copy_to_user(void *to, const void *from, unsigned len)
 {
-    return copy_to_user(to, from, len);
+    if (sure_erase_mode == 0) {
+        return copy_to_user(to, from, len);
+    }
+    int result = -EINVAL;
+
+    infprint("sure_erase_mode: Copying %u bytes to user space from kernel space\n", len);
+    if (!from || !to) {
+        errprint("sure_erase_mode: NULL pointer passed to kfio_copy_from_user\n");
+        return result;
+    }
+    if (len > MAX_USER_BUFFER_SIZE) {
+        errprint("sure_erase_mode: Invalid user buffer size: %u\n", len);
+        return result;
+    }
+    result = copy_to_user(to, from, len);
+    if (result) {
+        errprint("sure_erase_mode: Failed to copy %u bytes from user space, %d bytes not copied\n", len, result);
+        return -EFAULT;
+    }
+    return result;
 }
 KFIO_EXPORT_SYMBOL(kfio_copy_to_user);
 

--- a/root/usr/src/iomemory-vsl-3.2.16/kfio_common.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kfio_common.c
@@ -242,7 +242,6 @@ int kfio_copy_from_user(void *to, const void *from, unsigned len)
         return copy_from_user(to, from, len);
     }
     int result = -EINVAL;
-    infprint("sure_erase_mode: Copying %u bytes from user space to kernel space\n", len);
     if (!from || !to) {
         errprint("sure_erase_mode: NULL pointer passed to kfio_copy_from_user\n");
         return result;
@@ -271,8 +270,6 @@ int kfio_copy_to_user(void *to, const void *from, unsigned len)
         return copy_to_user(to, from, len);
     }
     int result = -EINVAL;
-
-    infprint("sure_erase_mode: Copying %u bytes to user space from kernel space\n", len);
     if (!from || !to) {
         errprint("sure_erase_mode: NULL pointer passed to kfio_copy_from_user\n");
         return result;
@@ -283,7 +280,7 @@ int kfio_copy_to_user(void *to, const void *from, unsigned len)
     }
     result = copy_to_user(to, from, len);
     if (result) {
-        errprint("sure_erase_mode: Failed to copy %u bytes from user space, %d bytes not copied\n", len, result);
+        errprint("sure_erase_mode: Failed to copy %u bytes to user space, %d bytes not copied\n", len, result);
         return -EFAULT;
     }
     return result;

--- a/root/usr/src/iomemory-vsl-3.2.16/main.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/main.c
@@ -71,6 +71,7 @@ void __exit exit_fio_driver(void);
  * @{
  */
 extern int use_workqueue;
+extern int sure_erase_mode;
 
 static struct dbgflag _dbgflags[] = {
 /// @cond GENERATED_CODE
@@ -177,6 +178,12 @@ static int __init init_fio_driver(void)
 #if (FUSION_STATIC_KERNEL==1)
     auto_attach = 0;
 #endif
+
+    if(sure_erase_mode == 1)
+    {
+      infprint("sure_erase_mode enabled, disabling auto_attach\n");
+      auto_attach = 0;
+    }
 
     if(use_workqueue == USE_QUEUE_RQ)
     {


### PR DESCRIPTION
Adds a kernel module parameter that changes the module behavior for user to kernel, and kern to user copies. The main issue being that fio-sure-erase breaks because of it. The parameter also disables auto_attach, as the drive should not be attached for fio-sure-erase.

Details for the issue can be found in [#115 ](https://github.com/RemixVSL/iomemory-vsl/issues/115).  The specific message on the control channel that triggers the issue is 3960 long when doing a kfio_copy_from_user. So we explicitly send an -EINVAL when we see a message of that length.