### PR TITLE
Partially revert "update fio rules for part sub"

### DIFF
--- a/tools/udev/rules.d/60-persistent-fio.rules
+++ b/tools/udev/rules.d/60-persistent-fio.rules
@@ -17,6 +17,9 @@ ENV{DEVTYPE}=="partition", \
   IMPORT{parent}="ID_F[!S]*", IMPORT{parent}="ID_F", \
   IMPORT{parent}="ID_FS[!_]*", IMPORT{parent}="ID_FS"
 
+# probe filesystem metadata of disks
+IMPORT{builtin}="blkid"
+
 # by-id
 KERNEL=="fio[a-z]", PROGRAM="/usr/bin/fio-status --field iom.format_uuid /dev/%k", SYMLINK+="disk/by-id/fio-%c"
 KERNEL=="fio[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/usr/bin/fio-status --field iom.format_uuid /dev/%P", SYMLINK+="disk/by-id/fio-%c-part%n"


### PR DESCRIPTION
This partially reverts commit 1395e633115912a2ccb524411b587c5f1f0ca10e.

This reverts the removal of `IMPORT{builtin}="blkid"`, restoring the filesystem metadata probe on fioX disks (needed for e.g. LVM auto-activation via `ID_FS_TYPE`).