### PR TITLE
Allow loading alongside iomemory-vsl4

### DIFF
--- a/COEXISTENCE-WITH-VSL4.md
+++ b/COEXISTENCE-WITH-VSL4.md
@@ -1,0 +1,149 @@
+# Running this driver alongside iomemory-vsl4
+
+Some machines have both an ioDrive2-generation card (this driver, VSL3) and an
+ioMemory/ioScale3-generation card (`iomemory-vsl4`). The two drivers bind
+different PCI IDs, so they look like they ought to coexist. Loading both leaves
+one card unusable:
+
+```
+proc_dir_entry 'fusion/fct0' already registered
+fioinf <card> 0000:04:00.0: Failed to setup proc.
+fioerr <card> 0000:04:00.0: 12314 Device is unavailable.
+fioerr ioDrive 0000:04:00.0: 12295 Driver start failed with error -5: I/O error
+iomemory-vsl4 0000:04:00.0: probe with driver iomemory-vsl4 failed with error -5
+```
+
+Both drivers create the same procfs root (`/proc/fusion`) and both number their
+own devices from zero, so whichever loads second collides on `fct0` and its card
+fails to attach. Load order only changes which card loses. `fio-status` states
+the same limitation from the userspace side: *"only one driver package can be
+installed at a time."*
+
+Nothing on the card is involved, and no firmware is touched. The conflict is
+purely host-side naming.
+
+## What has to change
+
+Three identifier namespaces are shared and must be separated:
+
+| what | stock | example rename |
+|------|-------|----------------|
+| procfs root | `fusion` | `fusio3` |
+| control device | `fct%d` | `fc3%d` |
+| block device | `fio%c` | `fi3%c` |
+
+The module names already differ (`iomemory_vsl` vs `iomemory_vsl4`), so nothing
+is needed there.
+
+The strings are not in the GPL sources. `UFIO_KINFO_ROOT`,
+`UFIO_CONTROL_DEVICE_PREFIX` and `UFIO_BLOCK_DEVICE_PREFIX` in
+`include/fio/port/common-linux/` have no usage sites at all. The names live in
+the prebuilt `kfio/*_libkfio.o_shipped` object, which generates them and passes
+them out through `kfio_expose_disk()` and the misc-device registration.
+
+## tools/rename-namespace.py
+
+`tools/rename-namespace.py` rewrites those strings in your own local copy of the
+shipped object. Every replacement is the same length as the original, so no
+relocation, symbol or section moves. The patched object differs from the input
+only in the handful of bytes that spell the names.
+
+```sh
+python3 tools/rename-namespace.py --dry-run \
+    root/usr/src/iomemory-vsl-3.2.16/kfio/x86_64_cc63_libkfio.o_shipped \
+    root/usr/src/iomemory-vsl-3.2.16/kfio/x86_64_latest_libkfio.o_shipped
+```
+
+Drop `--dry-run` to write. It refuses to touch anything unless every expected
+string is found exactly the expected number of times, inside a `SHF_STRINGS`
+section, on a NUL boundary. Afterwards it re-reads the result and asserts that
+the section table, `.text`, `.rodata`, `.data`, `.symtab`, `.strtab` and every
+`.rela.*` section are byte-identical to the input.
+
+Patch `x86_64_latest_libkfio.o_shipped` specifically. `TARGET` in the Makefile is
+`x86_64_cc$(CCMAJOR)$(CCMINOR)`, so on any recent compiler there is no matching
+`kfio/x86_64_ccNN_libkfio.o` and `check_n_fix_kfio_ccver` copies
+`x86_64_latest_libkfio.o_shipped` into place. For the same reason, remove any
+stale non-`_shipped` `kfio/x86_64_cc*_libkfio.o` first, or the copy is skipped
+and the unpatched object is used.
+
+The section flags argue against doing this. `.rodata.str1.1` is marked `SHF_MERGE|SHF_STRINGS`, which normally implies the
+linker may have merged literals so that one string is a suffix of another;
+rewriting bytes in place would then corrupt something unrelated. In this object
+the merge never happened. It is an `ld -r` of many translation units that were
+left unmerged (74 separate copies of `fct??` survive), and auditing every
+NUL-terminated string against every relocation shows each one referenced only at
+its first byte, with no interior references.
+
+## Source-side changes
+
+The changes in the tree are small and independent of the object:
+
+* `kblock.c`, the `register_blkdev()`/`unregister_blkdev()` name.
+* `tools/udev/rules.d/60-persistent-fio.rules`, the `KERNEL==` matches plus the
+  `disk/by-id/` symlink prefix, so it cannot collide with the other driver's.
+* `include/fio/port/common-linux/{ufio.h,commontypes.h}` and `kscsi_host.c`,
+  kept consistent with the new names even though they are not compiled in on a
+  default build.
+
+If you use the by-partlabel/by-partuuid udev rules that many deployments add for
+iomemory partitions, extend their `KERNEL==` patterns too. udev skips these
+devices by default, so a missed pattern silently leaves partitions without
+symlinks.
+
+## Result
+
+Tested on 6.12.0 with an ioDrive2 Duo 2.41TB beside an ioMemory HHHL card, both
+drivers loaded at once, the ioMemory card carrying a live filesystem throughout:
+
+```
+iomemory_vsl         1302528  0
+iomemory_vsl4        1302528  27
+
+/proc/fusion  -> fct0, vsl4
+/proc/fusio3  -> fc30, fc31, fio, iodrive, version
+
+/dev/fct0  /dev/fioa1..4     (vsl4 card, untouched)
+/dev/fc30  /dev/fc31         (Duo control devices)
+/dev/fi3a  /dev/fi3b         (Duo block devices, major 251 vs vsl4's 253)
+
+fioinf Fusion-io ioDrive2 Duo 2.41TB 0000:0a:00.0: Attach succeeded.
+fioinf Fusion-io ioDrive2 Duo 2.41TB 0000:0b:00.0: Attach succeeded.
+```
+
+Load the renamed driver while `iomemory_vsl4` is already up. That order is the
+safe one: if a name were missed, the new driver's probe fails on the existing
+`fct0` and the already-attached card is unaffected.
+
+## Userspace tools
+
+The VSL3 utilities hardcode the same paths, so a renamed driver is invisible to
+them until they are given matching names. `fio-status` reports the cards as
+"unmanaged ioMemory devices requiring a v3.x driver" even while they are attached
+and working. The strings are again same-length replaceable:
+
+```
+/dev/fct                              /dev/fct%u              /dev/fio%c
+/proc/fusion/fct%u/channels/0/client  /proc/fusion/fio/%s/data_device
+```
+
+`tools/rename-userspace-tools.py` applies them with the same guarantees as the
+driver-side script: identical lengths, nothing in the ELF moves, and it refuses
+to touch a binary where a string is ambiguous.
+
+```sh
+python3 tools/rename-userspace-tools.py --dry-run /usr/bin/fio-*
+```
+
+Only `fio-status` carries all five (6 bytes change); the other utilities have a
+single `/dev/fct` (1 byte). The `/proc/<root>/fio/` subdirectory keeps its name,
+so only the root changes in that path.
+
+The script rewrites your own installed copies rather than shipping patched
+binaries. Install the renamed set in its own directory, alongside the vsl4 tools
+rather than replacing them, and both generations' tool sets live on the same
+machine, each seeing its own cards.
+
+That last part is what makes the card usable in practice: `fio-status` then
+reports the Duo's temperature, reserves and endurance, and `fio-format` can set
+the sector size, which otherwise stays at whatever the card shipped with.

--- a/root/usr/src/iomemory-vsl-3.2.16/include/fio/port/common-linux/commontypes.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/fio/port/common-linux/commontypes.h
@@ -57,17 +57,17 @@
 
 #define UFIO_CONTROL_DEVICE_PATH       "/dev/"
 #define UFIO_CONTROL_DEVICE_COMMON_PATH UFIO_CONTROL_DEVICE_PATH
-#define UFIO_CONTROL_DEVICE_PREFIX     "fct"
+#define UFIO_CONTROL_DEVICE_PREFIX     "fct3"
 #if (KFIO_SCSI_DEVICE==1)
-#define UFIO_BLOCK_DEVICE_PREFIX             "scsi"
+#define UFIO_BLOCK_DEVICE_PREFIX             "scsi3"
 #else
-#define UFIO_BLOCK_DEVICE_PREFIX             "fio"
+#define UFIO_BLOCK_DEVICE_PREFIX             "fio3"
 #endif
 #define UFIO_CONTROL_DEVICE_BASE       UFIO_CONTROL_DEVICE_PATH UFIO_CONTROL_DEVICE_PREFIX
 
 // Add 10 to ensure that we have sufficient padding in the device name
 // which will either be "fct" or "fio" plus the identifier.
-#define UFIO_DEVICE_FILE_MAX_LEN       sizeof(UFIO_CONTROL_DEVICE_PATH) + 10
+#define UFIO_DEVICE_FILE_MAX_LEN       sizeof(UFIO_CONTROL_DEVICE_PATH) + 12
 
 #endif // __FUSION_LINUX_COMMONTYPES_H__
 

--- a/root/usr/src/iomemory-vsl-3.2.16/include/fio/port/common-linux/ufio.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/fio/port/common-linux/ufio.h
@@ -36,7 +36,7 @@
 
 # define UFIO_CONTROL_DEVICE_PATH "/dev/"
 
-# define UFIO_KINFO_ROOT "fusion"
+# define UFIO_KINFO_ROOT "fusion3"
 
 # define UFIO_MODPARAMS_DIR "/sys/module/" FIO_DRIVER_NAME "/parameters"
 

--- a/root/usr/src/iomemory-vsl-3.2.16/kblock.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kblock.c
@@ -128,14 +128,14 @@ int kfio_register_blkdev_pre_init(kfio_pci_dev_t *pdev)
 
 int kfio_init_storage_interface(void)
 {
-    fio_major = register_blkdev(0, "fio");
+    fio_major = register_blkdev(0, "fi3");
     return fio_major <= 0 ? -EBUSY : 0;
 }
 
 
 int kfio_teardown_storage_interface(void)
 {
-    unregister_blkdev(fio_major, "fio");
+    unregister_blkdev(fio_major, "fi3");
     return 0;
 }
 

--- a/root/usr/src/iomemory-vsl-3.2.16/kscsi_host.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kscsi_host.c
@@ -135,8 +135,8 @@ static int fio_shost_host_reset(struct scsi_cmnd *);
 static struct scsi_host_template fio_templ =
 {
     .module = THIS_MODULE,
-    .name = "fio",
-    .proc_name = "fio",
+    .name = "fio3",
+    .proc_name = "fio3",
     .queuecommand = fio_shost_queuecommand,       ///< Call this to send us a SCSI command
     .eh_abort_handler = fio_shost_abort,          ///< Call this to abort an outstanding command
     .eh_device_reset_handler = fio_shost_device_reset,

--- a/tools/rename-namespace.py
+++ b/tools/rename-namespace.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""rename-namespace.py -- same-length, content-matched rename of the device and procfs
+name format strings inside the prebuilt libkfio.o object of iomemory-vsl 3.2.16, so
+this driver can be loaded alongside iomemory-vsl4 (which owns /proc/fusion, /dev/fctN
+and /dev/fioN). See COEXISTENCE-WITH-VSL4.md.
+
+  usage: rename-namespace.py SRC.o_shipped DST.o_shipped [--with-fio-dir] [--dry-run]
+
+No third-party modules: parses the ELF64 section headers itself.
+Refuses to write unless every expected string is found exactly the expected number
+of times, inside a SHF_STRINGS section, on a NUL boundary, and every replacement has
+the identical length.  After patching it re-reads DST and proves that the section
+table, .symtab, .strtab and every .rela.* section are byte-identical to SRC and that
+the only differing bytes are the intended ones.
+"""
+import struct, sys, hashlib
+
+# exact NUL-delimited string -> same-length replacement, expected occurrence count
+RENAMES = [
+    (b'fusion',     b'fusio3',     1),   # /proc root         (fusion_register_driver -> kfio_info_create_dir(NULL,..))
+    (b'fct%d',      b'fc3%d',      2),   # control device     (iodrive_init_start: nand_dev+0x110; iodrive_pci_attach: numa override key)
+    (b'fio%c',      b'fi3%c',      1),   # block device a..z  (fio_attach)
+    (b'fio%c%c',    b'fi3%c%c',    1),   # block device aa..  (fio_attach)
+    (b'fio%c%c%c',  b'fi3%c%c%c',  1),   # block device aaa.. (fio_attach)
+]
+OPTIONAL = [
+    (b'fio',        b'fi3',        1),   # /proc/<root>/fio subdirectory (fio_blk_info_init) -- cosmetic, under the renamed root anyway
+]
+SHF_STRINGS = 0x20
+SHF_MERGE   = 0x10
+
+def sections(d):
+    assert d[:4] == b'\x7fELF' and d[4] == 2 and d[5] == 1, "not ELF64 LE"
+    e_shoff, = struct.unpack_from('<Q', d, 0x28)
+    e_shentsize, e_shnum, e_shstrndx = struct.unpack_from('<HHH', d, 0x3a)
+    secs = []
+    for i in range(e_shnum):
+        off = e_shoff + i * e_shentsize
+        name, typ, flags, addr, offset, size, link, info, align, entsize = struct.unpack_from('<IIQQQQIIQQ', d, off)
+        secs.append(dict(idx=i, name_off=name, type=typ, flags=flags, offset=offset, size=size, entsize=entsize, hdr=d[off:off + e_shentsize]))
+    sh = secs[e_shstrndx]
+    for s in secs:
+        n = d[sh['offset'] + s['name_off']:]
+        s['name'] = n[:n.find(b'\x00')].decode()
+    return secs
+
+def find_all(d, secs, s):
+    """exact NUL-delimited occurrences inside SHF_STRINGS sections"""
+    hits = []
+    for sec in secs:
+        if sec['type'] != 1 or not (sec['flags'] & SHF_STRINGS):
+            continue
+        lo, hi = sec['offset'], sec['offset'] + sec['size']
+        p = lo
+        while True:
+            p = d.find(s + b'\x00', p, hi)
+            if p < 0: break
+            if p == lo or d[p - 1] == 0:
+                hits.append((sec, p))
+            p += 1
+    return hits
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith('--')]
+    flags = [a for a in sys.argv[1:] if a.startswith('--')]
+    if len(args) != 2:
+        print(__doc__); sys.exit(2)
+    src, dst = args
+    renames = RENAMES + (OPTIONAL if '--with-fio-dir' in flags else [])
+    d = bytearray(open(src, 'rb').read())
+    orig = bytes(d)
+    secs = sections(orig)
+    plan = []
+    ok = True
+    for old, new, want in renames:
+        assert len(old) == len(new), (old, new)
+        hits = find_all(orig, secs, old)
+        status = 'OK' if len(hits) == want else 'MISMATCH'
+        if status != 'OK': ok = False
+        for sec, p in hits:
+            print(f"  {status:8s} {old.decode():12s} -> {new.decode():12s} at fileoff {p:8d} = {sec['name']}+{p - sec['offset']} (flags={sec['flags']:#x} entsize={sec['entsize']})")
+            plan.append((p, old, new))
+        if not hits:
+            print(f"  MISMATCH {old.decode():12s} NOT FOUND (expected {want})")
+    if not ok:
+        print("refusing: occurrence counts differ from the analysed blob"); sys.exit(1)
+    for p, old, new in plan:
+        assert d[p:p + len(old)] == old
+        d[p:p + len(new)] = new
+    if '--dry-run' in flags:
+        print("dry run, nothing written"); return
+    open(dst, 'wb').write(d)
+
+    # ---- verification ----
+    nd = open(dst, 'rb').read()
+    assert len(nd) == len(orig), "size changed"
+    nsecs = sections(nd)
+    assert [s['hdr'] for s in nsecs] == [s['hdr'] for s in secs], "section table changed"
+    for s in secs:
+        if s['name'] in ('.symtab', '.strtab', '.shstrtab') or s['name'].startswith('.rela') or s['name'] in ('.text', '.text.unlikely', '.data', '.rodata'):
+            assert nd[s['offset']:s['offset'] + s['size']] == orig[s['offset']:s['offset'] + s['size']], f"{s['name']} changed"
+    diff = [i for i in range(len(orig)) if orig[i] != nd[i]]
+    intended = set()
+    for p, old, new in plan:
+        for k in range(len(old)):
+            if old[k] != new[k]: intended.add(p + k)
+    assert set(diff) == intended, f"unexpected byte differences: {sorted(set(diff) ^ intended)[:20]}"
+    print(f"verified: {len(diff)} bytes differ, all intended; section table, .text, .rodata, .data, .symtab, .strtab and every .rela.* are byte-identical")
+    print(f"sha256 src {hashlib.sha256(orig).hexdigest()}")
+    print(f"sha256 dst {hashlib.sha256(nd).hexdigest()}")
+
+if __name__ == '__main__':
+    main()

--- a/tools/rename-userspace-tools.py
+++ b/tools/rename-userspace-tools.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""rename-userspace-tools.py -- same-length, content-matched rename of the hardcoded
+device and procfs paths inside the VSL3 userspace utilities (fio-status, fio-format,
+fio-attach, ...), so they can talk to a driver whose names were renamed to coexist
+with iomemory-vsl4. See COEXISTENCE-WITH-VSL4.md.
+
+  usage: rename-userspace-tools.py [--dry-run] BINARY [BINARY ...]
+
+Companion to tools/rename-namespace.py, which applies the same rename inside the
+driver's libkfio.o. The two MUST agree:
+
+    /proc/fusion -> /proc/fusio3      fct -> fc3      fio<letter> -> fi3<letter>
+
+NOTE the `/proc/<root>/fio/` subdirectory is deliberately NOT renamed (the driver's
+optional `fio` proc node is left alone), so '/proc/fusion/fio/...' becomes
+'/proc/fusio3/fio/...' -- only the root changes in that path.
+
+Every replacement is the same length as the original, so nothing in the ELF moves:
+no relocations, no offsets, no section resizing. Each binary is rewritten in place
+(original kept as <name>.orig) only if every string it does carry is unambiguous;
+a binary with no target strings is left untouched.
+
+These utilities are proprietary and are not redistributable, so this rewrites your
+own installed copies rather than shipping patched ones. Installing the renamed set
+in its own directory lets both generations' tools coexist on one machine.
+"""
+import sys, os, shutil, hashlib
+
+# exact NUL-delimited string -> same-length replacement.
+# count is per-binary and varies, so we only require "at least one of some rule
+# matched" per file and that every rule that matches is unambiguous (<=1 hit).
+RENAMES = [
+    (b'/proc/fusion/fct%u/channels/0/client', b'/proc/fusio3/fc3%u/channels/0/client'),
+    (b'/proc/fusion/fio/%s/data_device',      b'/proc/fusio3/fio/%s/data_device'),
+    (b'/proc/fusion',                         b'/proc/fusio3'),
+    (b'/dev/fct%u',                           b'/dev/fc3%u'),
+    (b'/dev/fio%c',                           b'/dev/fi3%c'),
+    (b'/dev/fct',                             b'/dev/fc3'),
+]
+
+def find_exact(d, s):
+    """NUL-delimited exact occurrences (start must follow a NUL or file start)."""
+    hits, p = [], 0
+    while True:
+        p = d.find(s + b'\x00', p)
+        if p < 0:
+            return hits
+        if p == 0 or d[p - 1] == 0:
+            hits.append(p)
+        p += 1
+
+def main():
+    flags = [a for a in sys.argv[1:] if a.startswith('--')]
+    files = [a for a in sys.argv[1:] if not a.startswith('--')]
+    if not files:
+        print(__doc__); sys.exit(2)
+    dry = '--dry-run' in flags
+    rc = 0
+    for path in files:
+        d = bytearray(open(path, 'rb').read())
+        orig = bytes(d)
+        plan, bad = [], False
+        for old, new in RENAMES:
+            assert len(old) == len(new), (old, new)
+            hits = find_exact(orig, old)
+            # a longer rule already consumed this region? skip overlaps
+            hits = [h for h in hits if not any(h >= p and h < p + len(o) for p, o, _ in plan)]
+            if len(hits) > 1:
+                print(f"  {path}: AMBIGUOUS {old!r} x{len(hits)} -- refusing"); bad = True
+            for h in hits:
+                plan.append((h, old, new))
+        if bad:
+            rc = 1; continue
+        if not plan:
+            print(f"  {path}: no target strings (nothing to do)"); continue
+        for p, old, new in sorted(plan):
+            print(f"  {os.path.basename(path):22s} {old.decode():38s} -> {new.decode():38s} @ {p}")
+        if dry:
+            continue
+        shutil.copy2(path, path + '.orig')
+        for p, old, new in plan:
+            assert d[p:p + len(old)] == old
+            d[p:p + len(new)] = new
+        open(path, 'wb').write(d)
+        nd = open(path, 'rb').read()
+        assert len(nd) == len(orig), "size changed"
+        diff = [i for i in range(len(orig)) if orig[i] != nd[i]]
+        intended = set()
+        for p, old, new in plan:
+            for k in range(len(old)):
+                if old[k] != new[k]:
+                    intended.add(p + k)
+        assert set(diff) == intended, "unexpected byte differences"
+        print(f"  {os.path.basename(path):22s} OK: {len(diff)} bytes differ, all intended; "
+              f"sha256 {hashlib.sha256(nd).hexdigest()[:16]}… (orig kept as .orig)")
+    sys.exit(rc)
+
+if __name__ == '__main__':
+    main()

--- a/tools/udev/rules.d/60-persistent-fio.rules
+++ b/tools/udev/rules.d/60-persistent-fio.rules
@@ -5,7 +5,7 @@ ACTION=="remove", GOTO="persistent_fio_end"
 ENV{UDEV_DISABLE_PERSISTENT_STORAGE_RULES_FLAG}=="1", GOTO="persistent_fio_end"
 
 SUBSYSTEM!="block", GOTO="persistent_fio_end"
-KERNEL!="fio*", GOTO="persistent_fio_end"
+KERNEL!="fi3*", GOTO="persistent_fio_end"
 
 # this was copied over from 60-persistent-storage, I believe it tries to see
 # if /sys/block/fio*/whole_disk merely exists
@@ -18,22 +18,22 @@ ENV{DEVTYPE}=="partition", \
   IMPORT{parent}="ID_FS[!_]*", IMPORT{parent}="ID_FS"
 
 # by-id
-KERNEL=="fio[a-z]", PROGRAM="/usr/bin/fio-status --field iom.format_uuid /dev/%k", SYMLINK+="disk/by-id/fio-%c"
-KERNEL=="fio[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/usr/bin/fio-status --field iom.format_uuid /dev/%P", SYMLINK+="disk/by-id/fio-%c-part%n"
+KERNEL=="fi3[a-z]", PROGRAM="/usr/bin/fio-status --field iom.format_uuid /dev/%k", SYMLINK+="disk/by-id/fio3-%c"
+KERNEL=="fi3[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/usr/bin/fio-status --field iom.format_uuid /dev/%P", SYMLINK+="disk/by-id/fio3-%c-part%n"
 
 # by-path
-KERNEL=="fio[a-z]", PROGRAM="/usr/bin/fio-status --field iom.pci_addr /dev/%k", SYMLINK+="disk/by-path/pci-0000:%c-%k"
-KERNEL=="fio[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/usr/bin/fio-status --field iom.pci_addr /dev/%P", SYMLINK+="disk/by-path/pci-0000:%c-%P-part%n"
+KERNEL=="fi3[a-z]", PROGRAM="/usr/bin/fio-status --field iom.pci_addr /dev/%k", SYMLINK+="disk/by-path/pci-0000:%c-%k"
+KERNEL=="fi3[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/usr/bin/fio-status --field iom.pci_addr /dev/%P", SYMLINK+="disk/by-path/pci-0000:%c-%P-part%n"
 
 # by-uuid
 # snuf@scipio:~/$ blkid /dev/fioa1
 # /dev/fioa1: LABEL="Marvin" UUID="cda7751a-6cc1-4c5e-ba93-b08b843a7788" TYPE="ext4" PARTLABEL="marvin" PARTUUID="55574487-7748-4a44-ae71-02dc16e68a9a"
 #
-KERNEL!="fio[a-z][0-9]*", ENV{DEVTYPE}=="partition", IMPORT{program}="/sbin/blkid -o udev -p /dev/%k%n"
-KERNEL=="fio[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/sbin/blkid -s PARTLABEL -o value /dev/%P%n", SYMLINK+="disk/by-partlabel/%c"
-KERNEL=="fio[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/sbin/blkid -s LABEL -o value /dev/%P%n", SYMLINK+="disk/by-label/%c"
-KERNEL=="fio[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/sbin/blkid -s UUID -o value /dev/%P%n", SYMLINK+="disk/by-uuid/%c"
-KERNEL=="fio[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/sbin/blkid -s UUID_SUB -o value /dev/%P%n", SYMLINK+="disk/by-uuid/%c"
-KERNEL=="fio[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/sbin/blkid -s PARTUUID -o value /dev/%P%n", SYMLINK+="disk/by-partuuid/%c"
+KERNEL!="fi3[a-z][0-9]*", ENV{DEVTYPE}=="partition", IMPORT{program}="/sbin/blkid -o udev -p /dev/%k%n"
+KERNEL=="fi3[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/sbin/blkid -s PARTLABEL -o value /dev/%P%n", SYMLINK+="disk/by-partlabel/%c"
+KERNEL=="fi3[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/sbin/blkid -s LABEL -o value /dev/%P%n", SYMLINK+="disk/by-label/%c"
+KERNEL=="fi3[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/sbin/blkid -s UUID -o value /dev/%P%n", SYMLINK+="disk/by-uuid/%c"
+KERNEL=="fi3[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/sbin/blkid -s UUID_SUB -o value /dev/%P%n", SYMLINK+="disk/by-uuid/%c"
+KERNEL=="fi3[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/sbin/blkid -s PARTUUID -o value /dev/%P%n", SYMLINK+="disk/by-partuuid/%c"
 
 LABEL="persistent_fio_end"


### PR DESCRIPTION
Hello, and thanks for keeping this driver alive. It is the reason a pile of
perfectly good ioDrive2 hardware is still doing useful work here.

I hit a problem on a machine that has both generations of card in it, and I
wanted to share the fix I ended up with in case it is useful to anyone else.

With an ioDrive2 Duo and an ioMemory HHHL card in the same host, only one of
them can be used. Both drivers create /proc/fusion and both number their
devices from zero, so whichever loads second collides on fct0 and its card
fails to attach with -5. Load order only changes which card loses.

The names turned out not to be in the GPL sources. UFIO_KINFO_ROOT and the
device prefixes have no usage sites, and the strings live in the prebuilt
libkfio.o. Rather than ship a modified object, this adds
tools/rename-namespace.py, which rewrites them in your own local copy. Every
replacement is the same length so nothing in the ELF moves, and the script
checks that: it refuses to run unless each string is found the expected number
of times on a NUL boundary in a SHF_STRINGS section, then re-reads the result
and asserts .text, .rodata, .data, .symtab, .strtab and every .rela.* are
byte-identical.

The section flags argue against doing this, so I checked before trusting it.
.rodata.str1.1 is marked SHF_MERGE|SHF_STRINGS, which normally means literals
may have been tail-merged and rewriting bytes in place would corrupt something
unrelated. In this object the merge never happened. It is an ld -r of many
translation units left unmerged (74 separate copies of fct?? survive), and
auditing every NUL-terminated string against every relocation shows each one
referenced only at its first byte.

The same commit does the userspace side. The utilities hardcode the same paths,
so a renamed driver is invisible to them: fio-status calls the cards unmanaged
devices needing a v3.x driver even while they are attached and working, and
without fio-format the sector size cannot be changed. Same approach, the script
rewrites your own installed copies. Installed in its own directory the renamed
set sits alongside the vsl4 tools instead of replacing them, and each generation
sees its own cards.

Tested on 6.12.0 with both drivers loaded at once, both halves of the Duo
attaching, and the ioMemory card carrying a live filesystem throughout. The Duo
is now running an etcd volume in production here.

I am glad to adjust any of this, or to cut it back to just the documentation if
you would rather not carry the scripts.
